### PR TITLE
CFI-97 Set DurationSeconds on datasets role to 60 minutes

### DIFF
--- a/source/dea-app/src/storage/datasets.ts
+++ b/source/dea-app/src/storage/datasets.ts
@@ -71,7 +71,7 @@ export const defaultDatasetsProvider = {
   sourceIpValidationEnabled: getRequiredEnv('SOURCE_IP_VALIDATION_ENABLED', 'true') === 'true',
   deletionAllowed: getRequiredEnv('DELETION_ALLOWED', 'false') === 'true',
   datasetsRole: getRequiredEnv('DATASETS_ROLE', 'DATASETS_ROLE is not set in your lambda!'),
-  uploadPresignedCommandExpirySeconds: Number(getRequiredEnv('UPLOAD_FILES_TIMEOUT_MINUTES', '60')) * 60,
+  uploadPresignedCommandExpirySeconds: 3600,
   downloadPresignedCommandExpirySeconds: 15 * 60,
   awsPartition: getRequiredEnv('AWS_PARTITION', 'AWS_PARTITION is not set in your lambda!'),
 };


### PR DESCRIPTION
The DurationSeconds cannot exceed 60 minutes due to a hard restriction on role chaining imposed by AWS.

This PR removes the dependency on the upload timeout environment variable when setting this value.

The hope is that the role session duration can remain at 1 hour, but the pre-signed url expiry can be extended for the duration of the upload.
