### PR TITLE
Make DEA version available on frontend.

### DIFF
--- a/source/dea-ui/ui/src/components/BaseLayout.tsx
+++ b/source/dea-ui/ui/src/components/BaseLayout.tsx
@@ -12,6 +12,7 @@ import { layoutLabels } from '../common/labels';
 import Navigation from '../components/Navigation';
 import { useSettings } from '../context/SettingsContext';
 import { Notifications } from './common-components/Notifications';
+import packageJson from '../../package.json';
 
 export interface LayoutProps {
   navigationHide?: boolean;
@@ -35,6 +36,7 @@ export default function BaseLayout({
       <Head>
         <title>{settings.name}</title>
         <meta name="description" content={settings.description} />
+        <meta name="version" content={packageJson.version} />
       </Head>
       <AppLayout
         headerSelector="#header"


### PR DESCRIPTION
Currently there is no way to see the DEA version from the front end.

This can make it difficult to ascertain which version of the DEA application is deployed to each environment.

This PR is an attempt to make the version available.
Rather than display the version on the UI, the version will be embedded in the <meta> HTML tags, so should be available when viewing the page source.