### PR TITLE
Remove unused lifecycle rule

### DIFF
--- a/source/dea-backend/src/constructs/dea-backend-stack.ts
+++ b/source/dea-backend/src/constructs/dea-backend-stack.ts
@@ -16,7 +16,6 @@ import {
   LifecycleRule,
   HttpMethods,
   ObjectOwnership,
-  StorageClass,
 } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { deaConfig } from '../config';
@@ -227,23 +226,6 @@ export class DeaBackendConstruct extends Construct {
       id: 'DeaDatasetsDeleteIncompleteUploadsLifecyclePolicy',
     };
 
-    const moveToIntelligentTiering: LifecycleRule = {
-      id: 'DeaDatasetIntelligentTieringPolicy',
-      enabled: true,
-      transitions: [
-        {
-          transitionAfter: Duration.days(0),
-          storageClass: StorageClass.INTELLIGENT_TIERING,
-        },
-      ],
-      noncurrentVersionTransitions: [
-        {
-          transitionAfter: Duration.days(0),
-          storageClass: StorageClass.INTELLIGENT_TIERING,
-        },
-      ],
-    };
-
-    return [moveToIntelligentTiering, deleteIncompleteUploadsRule];
+    return [deleteIncompleteUploadsRule];
   }
 }


### PR DESCRIPTION
It is not necessary to create a custom rule to move objects into intelligent tiering, since the upload logic creates objects in Intelligent Tiering storage class by default.

See https://github.com/UKHomeOffice/digital-evidence-archive-on-aws/blob/main/source/dea-app/src/storage/datasets.ts#L92