### PR TITLE
Increase complexity of Cognito passwords.

### DIFF
--- a/source/dea-backend/src/constructs/dea-auth.ts
+++ b/source/dea-backend/src/constructs/dea-auth.ts
@@ -449,7 +449,7 @@ export class DeaAuth extends Construct {
       // Below is Basic Password Policy, though it is missing the ability for
       // banned passwords, password expiry, password history etc
       passwordPolicy: {
-        minLength: 8,
+        minLength: 16,
         requireLowercase: true,
         requireUppercase: true,
         requireDigits: true,


### PR DESCRIPTION
Security review indicated that the default password policy was not strong enough. Doubling the minimum password length increases the overall complexity of passwords, and the length of time required to crack them.