### PR TITLE
Enabled advanced security mode for Cognito user pool.

### DIFF
--- a/source/dea-backend/src/constructs/dea-auth.ts
+++ b/source/dea-backend/src/constructs/dea-auth.ts
@@ -21,6 +21,7 @@ import {
 import { RestApi } from 'aws-cdk-lib/aws-apigateway';
 import {
   AccountRecovery,
+  AdvancedSecurityMode,
   CfnIdentityPool,
   CfnIdentityPoolRoleAttachment,
   ClientAttributes,
@@ -493,6 +494,7 @@ export class DeaAuth extends Construct {
       },
       removalPolicy: deaConfig.retainPolicy(),
       lambdaTriggers,
+      advancedSecurityMode: AdvancedSecurityMode.AUDIT,
     });
 
     let domainPrefix = deaConfig.cognitoDomain();


### PR DESCRIPTION
Addressing security review finding which advises that Cognito advanced security should be enabled.
Have opted for setting audity only initially to avoid any users from being blocked from accessing DEA.