### PR TITLE
Remove call to focus

### DIFF
--- a/source/dea-ui/ui/src/components/buttons/DownloadButton.tsx
+++ b/source/dea-ui/ui/src/components/buttons/DownloadButton.tsx
@@ -66,7 +66,6 @@ function DownloadButton(props: DownloadButtonProps): JSX.Element {
           alink.rel = 'noopener';
           alink.style.display = 'none';
           window.open(downloadResponse.downloadUrl, '_blank');
-          window.focus();
           // sleep 5ms => common problem when trying to quickly download files in succession => https://stackoverflow.com/a/54200538
           // long term we should consider zipping the files in the backend and then downloading as a single file
           await sleep(100);


### PR DESCRIPTION
Tested this and it made no difference to the page blinking on file download.