### PR TITLE
ci(github): update to include secret scanning and add .env to gitignore

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+REPO_ROOT_DIR=$(git rev-parse --show-toplevel)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+docker run --rm -v "$REPO_ROOT_DIR:/app" trufflesecurity/trufflehog:latest git file:///app --only-verified  --branch="$CURRENT_BRANCH" --fail

--- a/.github/pull-request-workflow.yml
+++ b/.github/pull-request-workflow.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@v3.82.1
+        with:
+          extra_args: --only-verified
       - name: Viperlight Scan
         run: node common/scripts/install-run-rush.js viperlight-scan
       - name: Install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@v3.82.1
+        with:
+          extra_args: --only-verified                            
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@v3.82.1
+        with:
+          extra_args: --only-verified                      
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@v3.82.1
+        with:
+          extra_args: --only-verified                        
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build

--- a/README.md
+++ b/README.md
@@ -563,6 +563,15 @@ Please note that default DEA limits are conservative, but you can increase the n
 
 DEA does not protect against uploading viruses (as they can be considered evidence in certain investigations), therefore we recommend setting up anti-virus and other security protections, such as crowdstrike to ensure your Criminal Justice devices stay secure. A common product is Crowdstrike.
 
+## Contributing via Pull Requests
+
+Before commiting any changes please ensure that git hooks are enabled.
+The `pre-commit` hook lives in the [.githooks](./githooks) directory. The hooks may be activated by running the following command.
+
+```
+git config core.hooksPath .githooks
+```
+
 ## Creating a PR from a Commit(s)
 
 OPTIONAL: run commit hooks locally


### PR DESCRIPTION
As part of reviewing CFI GitHub repositories some changes were implemented:
These include:

Required approvals to 1
Dismiss stale pull request approvals
Status Checks need to be completed before merge
Signed Commits are needed
Not allowing members to bypass these requirements
Adding .env to .gitignore
Adding trufflehog to scan for secrets in both secrets and pre commit