### PR TITLE
Tune S3 for performance improvements.

### DIFF
--- a/source/dea-backend/src/constructs/dea-backend-stack.ts
+++ b/source/dea-backend/src/constructs/dea-backend-stack.ts
@@ -196,6 +196,7 @@ export class DeaBackendConstruct extends Construct {
     const datasetsBucket = new Bucket(this, 'S3DatasetsBucket', {
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       bucketKeyEnabled: true,
+      transferAcceleration: true,
       encryption: BucketEncryption.KMS,
       encryptionKey: key,
       enforceSSL: true,

--- a/source/dea-ui/ui/package.json
+++ b/source/dea-ui/ui/package.json
@@ -56,6 +56,7 @@
     "@aws-sdk/client-cognito-identity": "~3.474.0",
     "@aws-sdk/client-cognito-identity-provider": "~3.474.0",
     "@aws-sdk/client-s3": "~3.474.0",
+    "@aws-sdk/node-http-handler": "^3.374.0",
     "@aws/dea-app": "workspace:*",
     "@cloudscape-design/collection-hooks": "^1.0.20",
     "@cloudscape-design/component-toolkit": "~1.0.0-beta.25",


### PR DESCRIPTION
- Set max concurrent connections.
- Enable transfer acceleration on the dataset bucket.
- Increase the multipart upload chunk size to 300MB.