### PR TITLE
fix: HOMS-74 - Increased polling delay for audit log fetch

### DIFF
--- a/source/dea-ui/ui/src/api/cases.tsx
+++ b/source/dea-ui/ui/src/api/cases.tsx
@@ -147,7 +147,7 @@ export const getCaseAuditCSV = async (caseId: string): Promise<string> => {
   let maxRetries = 60;
   while (progressStatus.includes(auditResponse.status.valueOf()) && maxRetries > 0) {
     --maxRetries;
-    await delay(1000);
+    await delay(3000);
     auditResponse = await retrieveCaseAuditResult(caseId, auditId);
   }
 
@@ -172,7 +172,7 @@ export const getCaseFileAuditCSV = async (caseId: string, fileId: string): Promi
   let maxRetries = 60;
   while (progressStatus.includes(auditResponse.status.valueOf()) && maxRetries > 0) {
     --maxRetries;
-    await delay(1000);
+    await delay(3000);
     auditResponse = await retrieveCaseFileAuditResult(caseId, fileId, auditId);
   }
 
@@ -210,7 +210,7 @@ export const getSystemAuditCSV = async (): Promise<string> => {
   let maxRetries = 60;
   while (progressStatus.includes(auditResponse.status.valueOf()) && maxRetries > 0) {
     --maxRetries;
-    await delay(1000);
+    await delay(3000);
     auditResponse = await retrieveSystemAuditResult(auditId);
   }
 

--- a/source/dea-ui/ui/src/api/data-vaults.tsx
+++ b/source/dea-ui/ui/src/api/data-vaults.tsx
@@ -103,7 +103,7 @@ export const getDataVaultAuditCSV = async (dataVaultId: string): Promise<string>
   let maxRetries = 60;
   while (progressStatus.includes(auditResponse.status.valueOf()) && maxRetries > 0) {
     --maxRetries;
-    await delay(1000);
+    await delay(3000);
     auditResponse = await retrieveDataVaultAuditResult(dataVaultId, auditId);
   }
 
@@ -131,7 +131,7 @@ export const getDataVaultFileAuditCSV = async (dataVaultId: string, fileId: stri
   let maxRetries = 60;
   while (progressStatus.includes(auditResponse.status.valueOf()) && maxRetries > 0) {
     --maxRetries;
-    await delay(1000);
+    await delay(3000);
     auditResponse = await retrieveDataVaultFileAuditResult(dataVaultId, fileId, auditId);
   }
 


### PR DESCRIPTION
## Description

Downloading audit log export timing out - increased polling period to mitigate this.

https://jira.bics-collaboration.homeoffice.gov.uk/browse/HOMS-74

## Testing

Will test in sandbox.
- As a user I want to download audit logs now without it timing out.
