### PR TITLE
Configure small files to follow same checksum flow

### DIFF
--- a/source/dea-app/src/storage/datasets.ts
+++ b/source/dea-app/src/storage/datasets.ts
@@ -279,9 +279,9 @@ const handleUploadChecksum = async (
   s3Bucket: string,
   queueUrl: string
 ) => {
-  if (uploadedParts.length === 1) {
-    return uploadedParts[0].ChecksumSHA256;
-  }
+  // if (uploadedParts.length === 1) {
+  //   return uploadedParts[0].ChecksumSHA256;
+  // }
 
   // Add messsage to sqs for checksum calculation
   const sqsEntries: SendMessageBatchRequestEntry[] = [];


### PR DESCRIPTION
## Description

This is a tactical fix for [HOMS-75](https://jira.bics-collaboration.homeoffice.gov.uk/browse/HOMS-75). Prior to this fix, files uploaded <350MB would be uploaded as 1 part in a MultiPartUpload. 

The logic

```typescript
  if (uploadedParts.length === 1) {
    return uploadedParts[0].ChecksumSHA256;
  }
```

would pull the `ChecksumSHA256` from S3 directly for these 1-part uploads. However, currently the `ChecksumSHA256` is not generated:

```typescript
  try {
    response = await datasetsProvider.s3Client.send(
      new CreateMultipartUploadCommand({
        Bucket: datasetsProvider.bucketName,
        Key: s3Key,
        BucketKeyEnabled: true,
        ServerSideEncryption: 'aws:kms',
        ContentType: caseFile.contentType,
        StorageClass: 'INTELLIGENT_TIERING',
        // ChecksumAlgorithm: ChecksumAlgorithm.SHA256,
      })
    );
```

On first inspection, the line

```typescript
        // ChecksumAlgorithm: ChecksumAlgorithm.SHA256,
```

appears to be the culprit. However re-introducing that creates an error upon uploading the file:

> "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>InvalidRequest</Code><Message>Checksum Type mismatch occurred, expected checksum Type: sha256, actual checksum Type: null</Message><RequestId>9A3CND5AN2865VQ7</RequestId><HostId>fuU9hEUdjpizf8bD3fE08ZZ1E4SLoKnpv6fZsMut5/iPMTZtK0kYetqE/KSpWEzrlDXpOVDQWgQ=</HostId></Error>"

To fix this, every part would need to be sent with a SHA256 checksum; Something the application is not currently configured to do. The potential strategic solution would be to rectify this issue and have S3 generate SHA256 checksums once and for-all. However, for the time being, this tactical fix appears to have rectified the immediate issue

## Testing

Upload a small file via DEA's frontend to a case with a size of e.g. 10MB. Check the hash in the DEA UI of the file. The hash should now show. Previously it was not showing. Note, this will not fix historic uploads. Only new ones
