### PR TITLE
HOMS-125: Update to latest versions of 3rd party Actions

### DIFF
--- a/.github/actions/baseAction/action.yml
+++ b/.github/actions/baseAction/action.yml
@@ -10,12 +10,12 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js 24.x
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '24.15.0'
 
     - name: Cache Rush
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           common/temp/install-run
@@ -26,7 +26,7 @@ runs:
           ${{ runner.os }}-
 
     - name: Cache pnpm
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           common/temp/pnpm-store
@@ -36,7 +36,7 @@ runs:
           ${{ runner.os }}-
 
     - name: install pnpm
-      uses: pnpm/action-setup@v4.0.0
+      uses: pnpm/action-setup@v5.0.0
       with:
         version: 10.33.0
 

--- a/.github/pull-request-workflow.yml
+++ b/.github/pull-request-workflow.yml
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.82.1
+        uses: trufflesecurity/trufflehog@v3.95.2
         with:
           extra_args: --only-verified
       - name: Viperlight Scan
@@ -80,14 +80,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build
         run: |
           node common/scripts/install-run-rush.js build
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: GITHUBACTIONSESSION
@@ -107,14 +107,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build
         run: |
           node common/scripts/install-run-rush.js build
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: GITHUBACTIONSESSION
@@ -141,14 +141,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build
         run: |
           node common/scripts/install-run-rush.js build
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: GITHUBACTIONSESSION
@@ -176,14 +176,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build
         run: |
           node common/scripts/install-run-rush.js build
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: GITHUBACTIONSESSION
@@ -212,14 +212,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build
         run: |
           node common/scripts/install-run-rush.js build
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: GITHUBACTIONSESSION
@@ -238,14 +238,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build
         run: |
           node common/scripts/install-run-rush.js build
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: GITHUBACTIONSESSION
@@ -264,14 +264,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build
         run: |
           node common/scripts/install-run-rush.js build
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: GITHUBACTIONSESSION

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       CONFIGNAME: 'dev'
       STAGE: 'cfidev'
-      DOMAIN_PREFIX: 'deadev' 
+      DOMAIN_PREFIX: 'deadev'
     environment: dea-dev
     defaults:
       run:
@@ -25,18 +25,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.82.1
+        uses: trufflesecurity/trufflehog@v3.95.2
         with:
-          extra_args: --only-verified                            
+          extra_args: --only-verified
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build
         run: |
           node common/scripts/install-run-rush.js build
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: GITHUBACTIONSESSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,18 +22,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.82.1
+        uses: trufflesecurity/trufflehog@v3.95.2
         with:
-          extra_args: --only-verified                      
+          extra_args: --only-verified
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build
         run: |
           node common/scripts/install-run-rush.js build
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_TEST }}
           role-session-name: GITHUBACTIONSESSION
@@ -60,14 +60,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install
         uses: ./.github/actions/baseAction
       - name: Rush Build
         run: |
           node common/scripts/install-run-rush.js build
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_PROD }}
           role-session-name: GITHUBACTIONSESSION

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.82.1
+        uses: trufflesecurity/trufflehog@v3.95.2
         with:
           extra_args: --only-verified
       - name: Install
@@ -38,7 +38,7 @@ jobs:
         run: |
           node common/scripts/install-run-rush.js build
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_SANDBOX_HOMS_TEAM }}
           role-session-name: GITHUBACTIONSESSION


### PR DESCRIPTION
## Description

This change updates to use the latest major versions of 3rd party actions within GitHub Actions

Previously GitHub Actions was throwing the following warnings:

> [Deploy DEACFI Sandbox](https://github.com/UKHomeOffice/digital-evidence-archive-on-aws/actions/runs/24404200866/job/71282820194#step:15:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v3, actions/setup-node@v3, aws-actions/configure-aws-credentials@v1, pnpm/action-setup@v4.0.0. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This change resolves those

## Testing

The pipeline was run, building the app and deploying into an ephemeral environment in https://github.com/UKHomeOffice/digital-evidence-archive-on-aws/actions/runs/24838017619

The application seemed to function as normal, so it does seem that there were any issues with these pipeline version upgrades

## Ticket

https://jira.bics-collaboration.homeoffice.gov.uk/browse/HOMS-125

