### PR TITLE
Remove all events from CloudTrail

### DIFF
--- a/source/dea-backend/src/constructs/dea-audit-trail.ts
+++ b/source/dea-backend/src/constructs/dea-audit-trail.ts
@@ -164,13 +164,13 @@ export class DeaAuditTrail extends Construct {
     // that blocks access to the DDB table and the S3 evidence bucket
     // and put in the implementation guide that they can add this to the
     // IAM Roles for administrators/staff for the AWS account
-    const dataResources = [
-      {
-        type: 'AWS::S3::Object',
-        // data plane events for the datasets bucket only
-        values: [`${deaDatasetsBucket.bucketArn}/`],
-      },
-    ];
+    // const dataResources: unknown = [
+    //   {
+    //     type: 'AWS::S3::Object',
+    //     // data plane events for the datasets bucket only
+    //     values: [`${deaDatasetsBucket.bucketArn}/`],
+    //   },
+    // ];
     const partition = deaConfig.partition();
 
     const includeDynamoDBDataPlaneEvents =
@@ -179,17 +179,17 @@ export class DeaAuditTrail extends Construct {
       deaConfig.includeDynamoDataPlaneEventsInTrail();
 
     if (includeDynamoDBDataPlaneEvents) {
-      dataResources.push({
-        type: 'AWS::DynamoDB::Table',
-        // data plane events for the DEA dynamo table
-        values: [deaTableArn],
-      });
+      // dataResources.push({
+      //   type: 'AWS::DynamoDB::Table',
+      //   // data plane events for the DEA dynamo table
+      //   values: [deaTableArn],
+      // });
 
-      dataResources.push({
-        type: 'AWS::Lambda::Function',
-        // data plane events for our lambdas
-        values: ['arn:aws:lambda'],
-      });
+      // dataResources.push({
+      //   type: 'AWS::Lambda::Function',
+      //   // data plane events for our lambdas
+      //   values: ['arn:aws:lambda'],
+      // });
     }
 
     const cfnTrail = trail.node.defaultChild;
@@ -197,8 +197,8 @@ export class DeaAuditTrail extends Construct {
       cfnTrail.eventSelectors = [
         {
           includeManagementEvents: true,
-          readWriteType: ReadWriteType.ALL,
-          dataResources,
+          readWriteType: ReadWriteType.WRITE_ONLY,
+          dataResources: []
         },
       ];
     }


### PR DESCRIPTION
## Description

This change removes all events from CloudTrail to reduce costs. It was identified that CloudTrail was the single biggest operational expense within DEA's stack. This will reduce the level of detail within the application's audit, but potentially this would be a good thing, removing a lot of noise. But potentially _some_ of this would need re-instating to support a system-level audit

> [!NOTE]
> Write management events are still being used since a Trail needs to record _something_. However, this has been narrowed down to write events only. Further work would be required to remove the CloudTrail trail entirely from DEA, if desired

Ticket:

https://jira.bics-collaboration.homeoffice.gov.uk/browse/HOMS-127

## Testing

Interact with DEA and view the costs in the AWS console. Compare these costs to April 2026 and March 2026. Inspect the audit for a case and compare this to an audit prior to this change being made