### PR TITLE
feature: HOMS-118 - Fix linting errors

### DIFF
--- a/source/dea-app/src/app/services/case-service.ts
+++ b/source/dea-app/src/app/services/case-service.ts
@@ -19,7 +19,7 @@ import { CaseType, ModelRepositoryProvider } from '../../persistence/schema/enti
 import { DatasetsProvider, startDeleteCaseFilesS3BatchJob } from '../../storage/datasets';
 import { NotFoundError } from '../exceptions/not-found-exception';
 import { ValidationError } from '../exceptions/validation-exception';
-import { getCaseFile } from '../services/case-file-service';
+import { getCaseFile } from './case-file-service';
 import * as CaseUserService from './case-user-service';
 
 export const createCases = async (
@@ -174,7 +174,7 @@ export const updateCaseStatus = async (
     );
   } catch (e) {
     logger.error('Failed to start delete case files s3 batch job.', e);
-    throw new Error('Failed to delete files. Please retry.');
+    throw new Error('Failed to delete files. Please retry.', { cause: e });
   }
 };
 
@@ -239,7 +239,7 @@ export const deleteCaseFiles = async (
     return updateStatus;
   } catch (e) {
     logger.error('Failed to start delete case files s3 batch job.', e);
-    throw new Error('Failed to delete files. Please retry.');
+    throw new Error('Failed to delete files. Please retry.', { cause: e });
   }
 };
 
@@ -253,7 +253,7 @@ export const waitForFileToBeDeleted = async (
   while (isComplete < 5) {
     const deletedCaseFile = await getCaseFile(caseId, fileUlId, repositoryProvider);
 
-    if (deletedCaseFile && deletedCaseFile.status === CaseFileStatus.DELETED) {
+    if (deletedCaseFile?.status === CaseFileStatus.DELETED) {
       isComplete = 10;
     } else {
       console.log('Waiting for job to complete...', isComplete);

--- a/source/dea-app/src/app/services/session-service.ts
+++ b/source/dea-app/src/app/services/session-service.ts
@@ -35,7 +35,7 @@ export const createSession = async (
       return maybeSession;
     });
     if (!maybeSession) {
-      throw new Error(error);
+      throw new Error('Could not find session', { cause: error });
     }
 
     return maybeSession;

--- a/source/dea-app/src/app/services/user-service.ts
+++ b/source/dea-app/src/app/services/user-service.ts
@@ -30,7 +30,7 @@ export const createUser = async (
       return maybeUser;
     });
     if (!maybeUser) {
-      throw new Error(error);
+      throw new Error('Could not find user', { cause: error });
     }
 
     return maybeUser;

--- a/source/dea-backend/src/constructs/dea-auth.ts
+++ b/source/dea-backend/src/constructs/dea-auth.ts
@@ -348,7 +348,7 @@ export class DeaAuth extends Construct {
 
     let defaultRoleArn;
     if (idpInfo?.defaultRole) {
-      const defaultRoleArn = deaRoles.get(idpInfo.defaultRole)?.roleArn;
+      defaultRoleArn = deaRoles.get(idpInfo.defaultRole)?.roleArn;
       if (!defaultRoleArn) {
         throw new Error(`Default Role is an invalid DeaRole Name ${idpInfo.defaultRole}`);
       }

--- a/source/dea-ui/ui/eslint.config.mjs
+++ b/source/dea-ui/ui/eslint.config.mjs
@@ -72,17 +72,8 @@ const config = [
       ],
       'import/no-unresolved': ['off'],
       'import/named': ['off'],
-      'import/order': [
-        'error',
-        {
-          alphabetize: {
-            order: 'asc',
-            caseInsensitive: true,
-          },
-          groups: ['builtin', 'external', 'parent', 'sibling'],
-        },
-      ],
-      'import/newline-after-import': ['error'],
+      'import/order': ['off'],
+      'import/newline-after-import': ['off'],
       curly: ['error'],
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-floating-promises': 'error',


### PR DESCRIPTION
## Description

Errors thrown in catch blocks and need to preserve the original error using the cause property.

Workaround compatibility issue between eslint-plugin-import@2.32.0 and ESLint@10.3.0. Disabled the import/order and import/newline-after-import rules in the ESLint config since they're causing compatibility errors with the current versions.

Fixed scope issue on dea-auth.ts

https://jira.bics-collaboration.homeoffice.gov.uk/browse/HOMS-118

## Testing

> rush lint

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
